### PR TITLE
fix. fikset feil med hentDiskresjonskode

### DIFF
--- a/tiltak-persondata/src/main/java/no/nav/team_tiltak/felles/persondata/cache/DiskresjonskodeCache.java
+++ b/tiltak-persondata/src/main/java/no/nav/team_tiltak/felles/persondata/cache/DiskresjonskodeCache.java
@@ -38,7 +38,7 @@ public class DiskresjonskodeCache {
         diskresjonskodeOpt.ifPresent(diskresjonskode -> put(fnr, diskresjonskode));
     }
 
-    private void put(String fnr, Diskresjonskode diskresjonskode) {
+    public void put(String fnr, Diskresjonskode diskresjonskode) {
         cache.put(fnr, diskresjonskode);
     }
 


### PR DESCRIPTION
* hentDiskresjonskode hadde ikke fallback for tom respons fra PDL tom for diskresjonskode betyr UGRADERT. Denne fallbacken var bare implementert i hentDiskresjonskoder som returnerte en map.